### PR TITLE
Fix pausing after landing with Caps Lock or Shift on

### DIFF
--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -2453,10 +2453,11 @@ begin
         if (SDLPort.KeyPressed) then
          begin
           SDLPort.WaitForKeyPress(ch,ch2);
+          ch:=upcase(ch);
          end;
         if (ch=#0) and (Ch2=#68) then begin cupslut:=true; ch:=#27; end;
         if (Ch=#27) or (Ch=#13) then Out:=True;
-        if (Ch='p') then SDLPort.WaitForKeyPress(ch,ch2);
+        if (Ch='P') then SDLPort.WaitForKeyPress(ch,ch2);
 
         DeltaX:=Maki.X;
         DeltaY:=Maki.Y;


### PR DESCRIPTION
A very minor but easy to fix bug.

P key can be used as a pause button during the jump. The check is done in the main program code in two places, one for the phase before landing on line 1731, and for after landing on line 2459. The first one checks for an uppercase P input and is preceded by `ch:=upcase(ch);` on line 1705, during the second check however the input is never uppercased and instead the game checks for a lowercase P. This makes pausing using P key with Caps Lock on after landing impossible. This pull request fixes the issue.

The bug however does not affect the SDL version, but this is only due to Shift and Caps Lock key being ignored altogether in the `SDLPort.WaitForKeyPress` replacement for the `readkbd` procedure from the DOS version. Therefore the bug will appear by itself when that is fixed. 🤪

Moreover, the same bug also exists in DOS version of the game, so it should be backported if a new release is planned sometime (I think this bug is way too minor to justify a new release for just this fix alone).