### PR TITLE
Add support for aspect ratio correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ some buffer overflows have been fixed.
 | Alt+(Keypad) Plus | Increase window size |
 | Alt+(Keypad) Minus | Decrease window size |
 | Alt+R | Reset window if stretched |
+| Alt+A | Toggle 4:3 aspect ratio |
 
 ## Build
 

--- a/SDLPORT.PAS
+++ b/SDLPORT.PAS
@@ -28,7 +28,7 @@ implementation
         xRes = 320;
         yRes = 200;
         targetFrames = 70;
-        aspect: real = xRes / yRes;
+        aspectRes: real = xRes / yRes;
 
   var windowMultiplier: integer;
       window: PSDL_Window;
@@ -41,6 +41,7 @@ implementation
 
       windowResized: boolean;
       fullScreen: boolean;
+      aspect: real;
 
       timer: TSDL_TimerID;
       frameCount, lastFrameCount, subFrameCount, lastFrameTick: LongInt;
@@ -92,7 +93,7 @@ end;
 
 procedure ResetWindowSize;
 begin
-  SDL_SetWindowSize(window, xRes * windowMultiplier, yRes * windowMultiplier);
+  SDL_SetWindowSize(window, xRes * windowMultiplier, Round(yRes * windowMultiplier * aspectRes / aspect));
   windowResized := true;
 end;
 
@@ -104,6 +105,7 @@ end;
 procedure Init;
 begin
   windowMultiplier := 2;
+  aspect := aspectRes;
 
   if SDL_Init( SDL_INIT_VIDEO or SDL_INIT_TIMER ) < 0 then HALT;
 
@@ -334,6 +336,15 @@ begin
                   ResetWindowSize;
                   exit
                 end;
+              end;
+            SDL_SCANCODE_A :
+              begin
+                if (aspect <> aspectRes) then
+                  aspect := aspectRes
+                else
+                  aspect := 4 / 3;
+                ResetWindowSize;
+                exit;
               end;
           end;
         end;

--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -5704,6 +5704,7 @@ begin
  writeln(' * Alt+(Keypad) Plus  : Increase window size');
  writeln(' * Alt+(Keypad) Minus : Decrease window size');
  writeln(' * Alt+R              : Reset window if stretched');
+ writeln(' * Alt+A              : Toggle 4:3 aspect ratio');
  writeln('');
  writeln('-------');
  writeln('');


### PR DESCRIPTION
While it is true that the game used 320×200 px VGA video mode for graphics display, at the time of it's release all such software was meant to be displayed on a 4:3 CRT monitor. This pull request add an Alt+A keyboard shortcut for switching between the square-pixel 16:10 aspect ratio and the intended-but-stretched 4:3 aspect ratio. A similar option is available e.g. in the recent Android port of Deluxe Ski Jump 2 and works quite well there.

The default display mode is left unchanged, as without anti-aliasing the 4:3 mode looks rather wobbly at the default scaling ratio. However when aspect ratio correction is enabled on a 1600×1200 px display, it should give a nice and round 5:6 horizontal to vertical pixel scaling ratio, resulting in a sharp picture.