### PR TITLE
Fixes

### DIFF
--- a/MAKI.PAS
+++ b/MAKI.PAS
@@ -27,7 +27,7 @@ INTERFACE {ÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ}
   procedure Lopeta;
   procedure LukitseKirjoitusSivu(Sivu:LongInt);
 
-  procedure LaskeLinjat(var KeulaX:integer;kr:integer;pk:single);
+  procedure LaskeLinjat(var KeulaX:integer;kr:integer;pk:double);
   procedure AsetaMoodi(M:Word);
   function Profiili(x:integer):integer;
 
@@ -100,7 +100,7 @@ begin
 
 end;
 
-procedure LaskeLinjat(var KeulaX:integer;kr:integer;pk:single);
+procedure LaskeLinjat(var KeulaX:integer;kr:integer;pk:double);
 { linjojen pituudet voisi ladata nopeammin levylt„ ... }
 var       Y,X:LongInt;
           c : byte;

--- a/SDLPORT.PAS
+++ b/SDLPORT.PAS
@@ -79,19 +79,22 @@ begin
 end;
 
 function TimerCallback(interval: UInt32; param: Pointer): UInt32; cdecl;
-var frameIntervalMs, nowMs : LongInt;
+var frameIntervalMs, nowMs, elapsed : LongInt;
 begin
   frameIntervalMs := 1000 div targetFrames;
   nowMs := SDL_GetTicks();
-  subFrameCount += nowMs - lastFrameTick;
-  lastFrameTick := nowMs;
-
-  while (subFrameCount >= frameIntervalMs) do
+  elapsed := nowMs - lastFrameTick;
+  if (elapsed >= frameIntervalMs) then
   begin
-    dec(subFrameCount, frameIntervalMs);
-    inc(framecount);
-  end;
+    lastFrameTick := nowMs;
+    subFrameCount += elapsed;
 
+    while (subFrameCount >= frameIntervalMs) do
+    begin
+        dec(subFrameCount, frameIntervalMs);
+        inc(framecount);
+    end;
+  end;
   TimerCallback:=interval;
 end;
 
@@ -263,11 +266,11 @@ end;
 
 procedure WaitRaster;
 begin
+  lastFrameCount := framecount;
   while(lastFrameCount = framecount) do
   begin
     SDL_Delay(1);
   end;
-  lastFrameCount := framecount;
 end;
 
 function KeyPressed : boolean;

--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -774,15 +774,15 @@ var { SoundOn : array[0..5] of boolean; }
 
     kr : integer;
     ponnistus : integer;
-    qx : single;
+    qx : double;
 
 {    KeulaX : integer; }
 
     paras : integer;
 
-    kor,matka,px,pxk,py,t,pl,kkor {,makikulma} : single;
+    kor,matka,px,pxk,py,t,pl,kkor {,makikulma} : double;
 
-    umatka, ukor, upx : single;
+    umatka, ukor, upx : double;
     ux : integer;
 
     kulma1, kulmas, hp, x, y, height : integer;

--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -77,6 +77,7 @@ var
                              ja muuten se unohtuu... }
 
  ThisIsAHillRecord : integer;
+ LMaara : word;
 
 
 procedure MakeSendMe;
@@ -799,7 +800,6 @@ var { SoundOn : array[0..5] of boolean; }
 
     riski, laskuri : longint;
     tyylip : array[1..7] of integer;
-    LMaara : word;
 {    LStyle : byte; }
 
     score : integer;

--- a/SJ3HELP.PAS
+++ b/SJ3HELP.PAS
@@ -5,9 +5,9 @@ interface
 var ch, ch2 : char; { n„ppisglobaalit }
 
 procedure beep(beeptapa:byte);
-function round(r:single):longint;
+function round(r:double):longint;
 
-function nsqrt(x:single):single;
+function nsqrt(x:double):double;
 procedure putsaa;
 procedure clearchs;
 procedure waitforkey;
@@ -44,7 +44,7 @@ begin
 end {Wait} ;
 
 
-function round(r:single):longint;
+function round(r:double):longint;
 var l : longint;
 begin
  l := trunc(r);
@@ -96,8 +96,8 @@ function HexW(W: word): string; {Word}
        HexChars[(W and $000F)];
     end;
 
-function nsqrt(x:single):single;
-var temp : single;
+function nsqrt(x:double):double;
+var temp : double;
 begin
 
  temp:=sqrt(abs(x));

--- a/SJ3UNIT.PAS
+++ b/SJ3UNIT.PAS
@@ -66,7 +66,7 @@ type Stat_type = record
      Kr : integer;
      FrIndex, BkIndex : string[3];
      BkBright, BkMirror, VxFinal : byte;
-     Pk, PlSave : single;
+     Pk, PlSave : double;
      Profile : longint;
      HRName : NameStr;
      HRLen : integer;

--- a/TUULI.PAS
+++ b/TUULI.PAS
@@ -18,7 +18,7 @@ uses SJ3Graph, SJ3Help;
 
 var tsuun : boolean;      { kiinnostaako n„m„ kaikkia? }
     traja1, traja2 : integer;
-    tkulma : single;
+    tkulma : double;
     tuulix, tuuliy:integer;
     tpaikka : byte;
 


### PR DESCRIPTION
Make `LMaara` global. Its value stayed the same between `hyppy()` function calls by pure accident.

Mimic frame rate limiter more like the original DOS version does it, i.e. wait that a new frame starts before rendering instead of just waiting for any change to framecount. Also make frame counting more accurate.

Use double precision floating point arithmetic everywhere. With single precision floating points, implementation details of the compiler affect how calculations are made, e.g. when to widen the number to double precision and convert back to single decision. As such, using double precision everywhere isn't probably worse than compling the original code with Free Pascal, which might have different implementation details than Turbo Pascal that was originally used.

Because of the aforementioned compiler implementation details, using double precision is vital to be able to reproduce the precise computations in another programming language (see https://github.com/akheron/skijump3-remake).