### PR TITLE
Remove workaround for a fixed bug

### DIFF
--- a/SDLPORT.PAS
+++ b/SDLPORT.PAS
@@ -444,7 +444,7 @@ begin
             SDLK_LEFTBRACKET : keyPressed:=TSDL_KeyCode('{');
             SDLK_RIGHTBRACKET : keyPressed:=TSDL_KeyCode('}');
             SDLK_SEMICOLON : keyPressed:=SDLK_COLON;
-            {SDLK_QUOTE} TSDL_KeyCode('''') : keyPressed:=SDLK_QUOTEDBL; // bug in ev1313/Pascal-SDL-2-Headers - wrong value of SDLK_QUOTE
+            SDLK_QUOTE : keyPressed:=SDLK_QUOTEDBL;
             SDLK_BACKQUOTE : keyPressed:=TSDL_KeyCode('~');
             SDLK_BACKSLASH : keyPressed:=TSDL_KeyCode('|');
             SDLK_COMMA : keyPressed:=SDLK_LESS;


### PR DESCRIPTION
Remove workaround for a bug in ev1313/Pascal-SDL-2-Headers library which has been fixed: https://github.com/ev1313/Pascal-SDL-2-Headers/pull/79/files