### PR TITLE
Add invisible background support to KO pairs screen

### DIFF
--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -4392,7 +4392,19 @@ var temp,temp2,who : integer;
 
 begin
 
- newscreen(1,0);
+ if (InvBack) then
+  begin
+
+   SiirraStandardiPaletti;
+   TallennaAlkuosa(0);
+   SavytaPaletti(0,40);
+   AsetaPaletti;
+
+   DrawHillScreen;
+   DrawAnim(5,2,62); { logo kehiin }
+
+  end
+   else newscreen(1,0);
  fontcolor(240);
   writefont(30,6,lstr(94));
  fontcolor(241);
@@ -4426,6 +4438,12 @@ begin
     end;
 
  cupslut:=Waitforkey3(305,6,ch);
+
+ if (InvBack) then
+  begin
+   TakaisinAlkuosa(0);
+   AsetaPaletti;
+  end;
 
 end;
 

--- a/SJ3LIST.PAS
+++ b/SJ3LIST.PAS
@@ -118,17 +118,16 @@ begin
    if (InvBack) then { tota pit„„ tsiigata viel„... }
     begin
 
+     if (FirstPage) then
+      begin
+       SiirraStandardiPaletti;
+       TallennaAlkuosa(0);
+       SavytaPaletti(0,40);
+       AsetaPaletti;
+       FirstPage:=False;
+      end;
+
      DrawHillScreen;
-
-    if (FirstPage) then
-     begin
-      SiirraStandardiPaletti;
-      TallennaAlkuosa(0);
-      SavytaPaletti(0,40);
-      AsetaPaletti;
-      FirstPage:=False;
-     end;
-
      DrawAnim(5,2,62); { logo kehiin }
 
     end


### PR DESCRIPTION
To my knowledge the KO pairs screen is the only scoreboard where "Invisible scoreboard backgrounds" setting from "Jumping options" setup menu is not supported. In my opinion this screen is, maybe not a typical one, but certainly a scoreboard, since after the first round the jump points are being displayed there.

The changes to `SJ3.PAS` file add support for invisible background to that screen.

The changes to `SJ3LIST.PAS` reverse calling order in order to (hehe) prevent palette "flicker" when moving between two consecutive "invisible background" scoreboards.

![Zrzut ekranu z 2024-02-20 23-23-32](https://github.com/suomipelit/skijump3-sdl/assets/14991562/f02d3ffa-79fb-4094-b89c-54fda48d0ce5)
