### PR TITLE
Allow resetting wind in practice

### DIFF
--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -1601,8 +1601,10 @@ begin
     ch:=upcase(ch);
     if (ch=#0) and (ch2=#68) then begin cupslut:=true; ch:=#27; end;
     if (not cjumper) and ((kword(ch,ch2)=K[2]) or (ch=#13)) then out:=true; { liikkeelle }
-    if (ch=#0) and (ch2=#63) and (wcup) and (cupstyle=1) and
-       (index=NumPl) and (kierros=1) and (osakilpailu=1) then begin Tuuli.Alusta(windplace); end;
+    if (ch=#0) and (ch2=#63) and (
+     (treeni) or
+     ((wcup) and (cupstyle=1) and (index=NumPl) and (kierros=1) and (osakilpailu=1))
+    ) then begin Tuuli.Alusta(windplace); end;
     if (ch=#27) then out:=true;
    end;
      if (cjumper) and ((random(100)=0) or (laskuri>600)) then Out:=True;
@@ -1999,7 +2001,7 @@ begin
 
           pl:=pl+0.013;
           py:=py-1;
-          
+
 
           if (kierros>0) then stats[statsvictim,osakilpailu].Reason[kierros]:=1;
 


### PR DESCRIPTION
Currently, wind can be reset using the F5 key in the first jump of the first hill of a custom cup. This was introduced to help "online" competitions, as it is more convenient than pressing F10 and re-entering the cup for "wind-hunting", and the restrictive conditions ensure no objective advantage can be gained with that method (except for time saved of course).

This pull requests broadens aforementioned conditions to allow the wind to be reset in any training jump. In training you can change even the starting gate, so why not the wind :shrug: 