### PR TITLE
Fix box title name for CPU jumper select

### DIFF
--- a/SJ3INFO.PAS
+++ b/SJ3INFO.PAS
@@ -1805,7 +1805,7 @@ begin
   fillbox(74,79,246,133,248);
   fillbox(75,80,245,132,243);
 
-  writefont(85,85,lstr(219));
+  writefont(85,85,lstr(220));
   fontcolor(241);
   writefont(85,95,lstr(150));
 


### PR DESCRIPTION
Currently, when the "Select viewed computer jumpers" option in "Jumping options" setup menu is selected, a popup box with an incorrect translation string as a title is being displayed.

This pull request changes the incorrect "Draw Hill Record Goals?" title to the likely intended and definitely more correct "Select Viewed Computer Jumpers?".