### PR TITLE
Support keys G to L in menus

### DIFF
--- a/SJ3UNIT.PAS
+++ b/SJ3UNIT.PAS
@@ -843,8 +843,8 @@ begin  { phase: 0 - DEL ei k„y, 1 - DEL k„y, 2 - 2 columns! DEL k„y }
 
    case (ch) of
    '0'..'9' : index:=ord(ch)-48;
-   'A'..'F' : if (phase<>6) then index:=ord(ch)-55; { me halutaan ett„ E on edit }
-   'a'..'f' : index:=ord(ch)-87;
+   'A'..'K' : if (phase<>6) then index:=ord(ch)-55; { me halutaan ett„ E on edit }
+   'a'..'k' : index:=ord(ch)-87;
    end;
 
    if (index<=0) or (index>items) then

--- a/SJ3UNIT.PAS
+++ b/SJ3UNIT.PAS
@@ -843,8 +843,8 @@ begin  { phase: 0 - DEL ei k„y, 1 - DEL k„y, 2 - 2 columns! DEL k„y }
 
    case (ch) of
    '0'..'9' : index:=ord(ch)-48;
-   'A'..'K' : if (phase<>6) then index:=ord(ch)-55; { me halutaan ett„ E on edit }
-   'a'..'k' : index:=ord(ch)-87;
+   'A'..'L' : if (phase<>6) then index:=ord(ch)-55; { me halutaan ett„ E on edit }
+   'a'..'l' : index:=ord(ch)-87;
    end;
 
    if (index<=0) or (index>items) then


### PR DESCRIPTION
Menus rely on number keys for quick navigation. Press the number key corresponding to the menu item position and the menu cursor instantly moves there. Since some menus have more than 9 positions, additional letter keys A-F are supported. However, this makes little sense to me.

The only menu in which the menu positions past number 9. are displayed as "lettered" – A., B. etc., as opposed to regular numbering from 10. upwards – is the "Jumping options" screen of the Setup menu. But it only goes up to the letter B. However, this "letter-key-navigation" method works in all kinds of menus, even the "regularly-numbered" ones, and some of them go up to 20 positions (e.g. Jumpers menu, Practise jump menu). I see no reason to stop at F in particular, the menu item has nothing to do with the hexadecimal world, and not all players are programmers :wink: 

This pull requests increases letter-key range from `A..F` to `A..K` in order to facilitate quick navigation for all 20 possible menu items.

Edit: Actually, having custom hills extends Practise jump menu to 21 items ("More hills…" options is added), so I've extended the range to `A..L`

