### PR TITLE
Fix Wait procedure timing

### DIFF
--- a/SDLPORT.PAS
+++ b/SDLPORT.PAS
@@ -19,7 +19,7 @@ interface
   function KeyPressed : boolean;
   procedure WaitForKeyPress(var ch1, ch2 : char);
 
-  procedure Wait(ms : integer);
+  procedure Wait(ticks : integer);
 
 implementation
 
@@ -29,6 +29,7 @@ implementation
         yRes = 200;
         targetFrames = 70;
         aspectRes: real = xRes / yRes;
+        msPerTick: real = 1000 / 18.2065; { typical IBM PC PIT system clock tick rate }
 
   var windowMultiplier: integer;
       window: PSDL_Window;
@@ -475,7 +476,7 @@ begin
             SDLK_KP_PERIOD : keyPressed:=SDLK_DELETE;
           end;
         end;
-        
+
         // Merge keypad characters with their regular counterparts.
         // It is not needed to differentiate between them, since the scancode isn't checked for normal characters.
         // Checks for Shift and Num Lock were already done, so they won't interfere with the merge.
@@ -582,9 +583,9 @@ begin
   end;
 end;
 
-procedure Wait(ms : integer);
+procedure Wait(ticks : integer);
 begin
-  SDL_Delay(ms);
+  SDL_Delay(Round(ticks * msPerTick));
 end;
 
 end.

--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -5834,7 +5834,7 @@ begin
  lopputext(version_full,Start,Now);
 
  repeat
-  SdlPort.Wait(10);
+  SDLPort.Wait(1);
  until Crt.KeyPressed
 
 end;


### PR DESCRIPTION
The original DOS version implemented the Wait procedure by polling the [Programmable Interval Timer](https://wiki.osdev.org/Programmable_Interval_Timer) at the `0040:006C` memory address, and counting the number of ticks elapsed: https://github.com/suomipelit/skijump3/blob/master/SJ3HELP.PAS#L41C1-L50C13

The value at this address should increase (assuming the default configuration) every _65536/1193182 [s]_, that is with a frequency of _~18.2065 [Hz]_. But the `SDL_Delay` method accepts as a parameter time in milliseconds, not in IBM-compatible PIT tick number. So, a "unit" conversion is needed, from "ticks" to _ms_ — which is now missing.

This PR introduces the conversion, making the `Wait` timing consistent with the DOS version.  \
In-game, the delay length is probably most easily checked by turning on the "Beeps?" in General Options and taking-off too early.