### PR TITLE
Fix output character conversion

### DIFF
--- a/SDLPORT.PAS
+++ b/SDLPORT.PAS
@@ -4,6 +4,7 @@ interface
 
   type TPalette = Array[0..255,0..2] of byte;
   type TCloseCallback = procedure;
+  type TCharToUTF8Table = array[#128..#255] of RawByteString;
 
   function GetVersion : string;
 
@@ -20,6 +21,8 @@ interface
   procedure WaitForKeyPress(var ch1, ch2 : char);
 
   procedure Wait(ms : integer);
+
+  function ConvertToUTF8(s : string): UTF8String;
 
 implementation
 
@@ -475,7 +478,7 @@ begin
             SDLK_KP_PERIOD : keyPressed:=SDLK_DELETE;
           end;
         end;
-        
+
         // Merge keypad characters with their regular counterparts.
         // It is not needed to differentiate between them, since the scancode isn't checked for normal characters.
         // Checks for Shift and Num Lock were already done, so they won't interfere with the merge.
@@ -585,6 +588,26 @@ end;
 procedure Wait(ms : integer);
 begin
   SDL_Delay(ms);
+end;
+
+function ConvertToUTF8(s : string): UTF8String;
+const ArrayCP865ToUTF8 : TCharToUTF8Table = (
+  'Ç', 'ü', 'é', 'â', 'ä', 'à', 'å', 'ç', 'ê', 'ë', 'è', 'ï', 'î', 'ì', 'Ä', 'Å',
+  'É', 'æ', 'Æ', 'ô', 'ö', 'ò', 'û', 'ù', 'ÿ', 'Ö', 'Ü', 'ø', '£', 'Ø', '₧', 'ƒ',
+  'á', 'í', 'ó', 'ú', 'ñ', 'Ñ', 'ª', 'º', '¿', '⌐', '¬', '½', '¼', '¡', '«', '¤',
+  '░', '▒', '▓', '│', '┤', '╡', '╢', '╖', '╕', '╣', '║', '╗', '╝', '╜', '╛', '┐',
+  '└', '┴', '┬', '├', '─', '┼', '╞', '╟', '╚', '╔', '╩', '╦', '╠', '═', '╬', '╧',
+  '╨', '╤', '╥', '╙', '╘', '╒', '╓', '╫', '╪', '┘', '┌', '█', '▄', '▌', '▐', '▀',
+  'α', 'ß', 'Γ', 'π', 'Σ', 'σ', 'μ', 'τ', 'Φ', 'Θ', 'Ω', 'δ', '∞', 'φ', 'ε', '∩',
+  '≡', '±', '≥', '≤', '⌠', '⌡', '÷', '≈', '°', '∙', '·', '√', 'ⁿ', '²', '■', ' '
+);
+var i, l : integer;
+    tmp : UTF8String;
+begin
+  tmp := '';
+  l := Length(s);
+  for i:=1 to l do if s[i] > #127 then tmp += ArrayCP865ToUTF8[s[i]] else tmp += s[i];
+  ConvertToUTF8 := tmp;
 end;
 
 end.

--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -5730,7 +5730,7 @@ begin
  writeln('');
  writeln('-------');
  writeln('');
- writeln('SJ3 v',version,' by Ville Ken 2011');
+ writeln('SJ3 v',version,toansi(' by Ville K馬馬en 2013'));
 
  write('- Loading ANIM.SKI');
   LoadAnim('ANIM.SKI');
@@ -5796,7 +5796,7 @@ end;
 procedure loppu;
 begin
 
- writeln('SJ3 v',version,' by Ville Ken 2013');
+ writeln('SJ3 v',version,toansi(' by Ville K馬馬en 2013'));
 
  GetNow(Now);
 
@@ -5824,14 +5824,7 @@ begin
  textbackground(0);
  clrscr;
 
-  DoWindow(1,2,80,14,7);
-{$IFDEF REG}
- regendtext(regname,regnumber);
-{$ELSE}
- unregendtext;
-{$ENDIF}
-
- lopputext(version_full,Start,Now);
+ lopputext(version_full,regname,regnumber,Start,Now);
 
  repeat
   SdlPort.Wait(10);

--- a/SJ3HELP.PAS
+++ b/SJ3HELP.PAS
@@ -338,34 +338,8 @@ begin
 end;
 
 function toansi(str1:string):string;
-var outstr : string;
-    index  : integer;
 begin
-
- outstr:=str1;
-
- for index:=1 to length(outstr) do
-  begin
-   case outstr[index] of
-   '' : outstr[index]:='Â';
-   '' : outstr[index]:='Ä';
-   '™' : outstr[index]:='Ö';
-   'š' : outstr[index]:='Ü';
-   '' : outstr[index]:='Ø';
-   '’' : outstr[index]:='Æ';
-   '†' : outstr[index]:='å';
-   '„' : outstr[index]:='ä';
-   '”' : outstr[index]:='ö';
-   '' : outstr[index]:='ü';
-   '›' : outstr[index]:='ø';
-   '‘' : outstr[index]:='æ';
-   'á' : outstr[index]:='ß'; { beta? }
-   end;
-
-  end;
-
- toansi:=outstr;
-
+ toansi:=SDLPort.ConvertToUTF8(str1);
 end;
 
 

--- a/SJ3UNIT.PAS
+++ b/SJ3UNIT.PAS
@@ -112,7 +112,7 @@ procedure getch(xx,yy:integer;bkcolor:byte;var tempch,tempch2:char);
 function getstr(xx,yy,maxlength:integer;oldstr:string;bkcolor:byte):string;
 function getstr2(xx,yy,maxchars:integer;oldstr:string;bkcolor:byte):string;
 
-procedure lopputext(version:string;a1,a2:Time);
+procedure lopputext(version,regname,regnumber:string;a1,a2:Time);
 
 function MakeMenu(x,y,length,height,items,index:integer;bgcolor,phase,tab:byte):integer;
 
@@ -3039,22 +3039,29 @@ end;
 
 
 
-procedure lopputext(version:string;a1,a2:Time);
+procedure lopputext(version,regname,regnumber:string;a1,a2:Time);
 var out : Time;
     temp1, temp2, diff : longint;
 
 begin
+   textbackground(0);
+   clrscr;
 
+   textbackground(7);
    textcolor(0);
-   gotoxy(69,2);write(' лп л');
-   gotoxy(69,3);write(' л  л');
-   gotoxy(69,4);write('мл мл');
-
+   gotoxy(69,2);write(toansi('      '));
+   gotoxy(69,3);write(toansi(' лп л '));
+   gotoxy(69,4);write(toansi(' л  л '));
+   gotoxy(69,5);write(toansi('мл мл '));
    textcolor(4);
-   gotoxy(75,2);write('пл');
-   gotoxy(75,3);write('ўл');
-   gotoxy(75,4);write('мл');
+   gotoxy(75,2);write(toansi('      '));
+   gotoxy(75,3);write(toansi('пл    '));
+   gotoxy(75,4);write(toansi('ўл    '));
+   gotoxy(75,5);write(toansi('мл    '));
+   textbackground(0);
 
+   DoWindow(69,6,80,14,7);
+   DoWindow(1,2,68,14,7);
 
    temp1:=longint(a1.second)+longint(a1.minute)*60+longint(a1.hour)*3600;
    temp2:=longint(a2.second)+longint(a2.minute)*60+longint(a2.hour)*3600;
@@ -3105,9 +3112,13 @@ begin
  write('   webpage located at  ');
  cwrite(8,'http://www.nomasi.com/sj3/');
 
-  window(1,16,80,19);
-  textbackground(1);
-   clrscr;
+{$IFDEF REG}
+ regendtext(regname,regnumber);
+{$ELSE}
+ unregendtext;
+{$ENDIF}
+
+  DoWindow(1,16,80,19,1);
   writeln;
   cwriteln(9,'   Quote of the moment: ');
   cwrite(15,'   ');


### PR DESCRIPTION
This Pull request changes the implementation of the `SJ3HELP.toansi` function, so that the passed text in the IBM865 code page is converted not to an extended ASCII, but the UTF-8 encoding. This function was used for the `*.TXT` file output, and has been reused here for the console output also. This should result in a correct display of special characters on modern (especially non-Nordic?) systems.

A few tweaks, rearrangements and workarounds were needed for the `SJ3UNIT.lopputext` procedure, as the `Crt.Window` procedure seems not to handle multi-byte text output particularly well.

Outro screen (Ubuntu 24.04.4 LTS + fpc 3.2.2):
| Before | After |
| ------ | ----- |
| <img width="800" height="550" alt="Outro screen, before" src="https://github.com/user-attachments/assets/f6f7df26-677b-4c02-adb8-94335b725127" /> | <img width="800" height="550" alt="Outro screen, after" src="https://github.com/user-attachments/assets/6210d632-81fd-4409-a491-230c0cf04d91" /> |

This probably needs some testing on Windows & macOS too before merging.