### PR TITLE
Fix injury text

### DIFF
--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -2684,7 +2684,7 @@ begin
          if (inj[pel]=1) then str1:='LEG.';
          writefont(12,176,'WILL MISS NEXT '+txt(inj[pel])+str1); }
 
-           str1:=txt(inj[pel])+' '+lstr(76);
+           str1:=txt(inj[pel]-1)+' '+lstr(76);
 
            case inj[pel] of
            1 : str1:=lstr(77);


### PR DESCRIPTION
`inj[]` program variable is an array storing the injury status for every jumper. A value in the array is set to a value generated by the `SJ3UNIT.injured` function, if called after a fallen jump (`SJ3.PAS:2206`), and is decremented before every cup leg if greater than zero (`SJ3.PAS:5311`).

Therefore, the possible values (and their meanings) are:
* `0` — not injured
* `1` — _misses next round_ (in other words, only the rest of the current leg, and "0 next legs")
* `2..4` — _misses next 1..3 legs_

In the short form of the injury info text, the values `1..4` are always correctly displayed as _INJ-0..3_ (`SJ3.PAS:4006`).

But in the long form of the injury info text:
* value `1` is correctly displayed as _Misses Next Round_ (`SJ3.PAS:2690`)
* value `2` is correctly displayed as _Misses Next Leg_ (`SJ3.PAS:2691`)
* values `3..4` are **incorrectly** displayed as _Misses Next 3..4 Legs_, instead of _Misses Next 2..3 Legs_ (`SJ3.PAS:2687`)

This Pull Request fixes the last case.
