### PR TITLE
Fix unnecessary menu cursor position reset

### DIFF
--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -4485,9 +4485,9 @@ var temp : integer;
 
 
 
-function selecthill(phase:byte):byte; { 0 - train, 1 - koth, 2 - morehills, 3 - morehills KOTH }
-                                      { uusi: 0 - train, 1 - koth }
-var temp, gothill : integer;
+function selecthill(phase:byte;gothill:integer):byte; { 0 - train, 1 - koth, 2 - morehills, 3 - morehills KOTH }
+                                                      { uusi: 0 - train, 1 - koth }
+var temp : integer;
     hill : integer;
     str1 : string;
     items : integer;
@@ -4497,6 +4497,11 @@ var temp, gothill : integer;
 begin
 
  start:=0;
+ while (gothill>20) do
+  begin
+   dec(gothill,20);
+   inc(start,20);
+  end;
 
  repeat
 
@@ -4543,12 +4548,13 @@ begin
 
    DrawScreen;
 
-  gothill:=MakeMenu(110,11,170,8,items,1,243,0,0);
+  gothill:=MakeMenu(110,11,170,8,items,gothill,243,0,0);
 
   leave:=true;
 
   if (gothill=items) and (NumExtraHills>0) then
    begin
+    gothill:=1;
     inc(start,20);
     if (start>=NumExtraHills+NumWCHills) then start:=0;
     leave:=false;
@@ -4575,12 +4581,13 @@ begin
  cupslut:=false;
  ch:=#1;
  startgate:=15;
+ nytmaki:=1;
 
   repeat
 
    eka:=true;
 
-   nytmaki:=selecthill(0);
+   nytmaki:=selecthill(0,nytmaki);
 
    if (nytmaki=0) then cupslut:=true;
 
@@ -4842,6 +4849,7 @@ begin
 
  getkoth;
 
+ index:=1;
  repeat
 
  NewScreen(3,0);
@@ -4891,7 +4899,7 @@ begin
 
   DrawScreen;
 
-  index:=MakeMenu(10,10,160,10,6,1,245,0,3);
+  index:=MakeMenu(10,10,160,10,6,index,245,0,3);
 
   case index of
   1 : startkoth;
@@ -4900,7 +4908,7 @@ begin
        DrawScreen;
 
        temp:=kothpack;
-       kothpack:=MakeMenu(10,121,160,8,6,1,244,0,254);
+       kothpack:=MakeMenu(10,121,160,8,6,kothpack,244,0,254);
 {$IFNDEF REG}
        if ((kothpack<1) or (kothpack>6)) then kothpack:=temp;
 {$ENDIF}
@@ -4914,7 +4922,7 @@ begin
       end; { else if (beeppi) then beep(2); }
   4 : begin
        kothpack:=0;
-       kothmaki:=selecthill(1);
+       kothmaki:=selecthill(1,kothmaki);
       end; { else if (beeppi) then beep(2); }
   5 : begin
        kothpack:=0;

--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -614,7 +614,7 @@ begin
    0 : begin
 
         case index[screen] of
-        1,2,3 : screen:=index[screen];
+        1,2,3 : begin screen:=index[screen]; index[screen]:=1; end;
         4 : configurekeys(K);
 {$IFDEF REG}
         5 : setgoals;

--- a/SJ3INFO.PAS
+++ b/SJ3INFO.PAS
@@ -1790,7 +1790,7 @@ begin
     writefont(x-(fontlen(lnames[temp]) div 2),temp*8+55,lnames[temp]);
 
   temp:=3; if (not full) then temp:=7;
- index:=MakeMenu(112,64,100,8,numlanguages-1,1,243,temp,0);
+ index:=MakeMenu(112,64,100,8,numlanguages-1,languagenumber,243,temp,0);
 
  if (index=0) then index:=numlanguages;
 

--- a/SJ3UNIT.PAS
+++ b/SJ3UNIT.PAS
@@ -765,6 +765,16 @@ var{ tempch1,tempch2 : char; }
     oldindex : integer;
     thing : integer;
 
+function GetLastIndex:integer;
+begin
+ if (putkeen) then GetLastIndex:=items+1 else GetLastIndex:=items+2;
+end;
+
+procedure NormalizeIndex;
+begin
+ if (index<=0) or (index>items) then index:=GetLastIndex;
+end;
+
 begin  { phase: 0 - DEL ei k„y, 1 - DEL k„y, 2 - 2 columns! DEL k„y }
        {        3 - kaikki putkeen, 4 - ei fillarea, 5 - old players }
        {        6 - new profiles, 7 - kaikki putkeen & ei fill }
@@ -796,6 +806,7 @@ begin  { phase: 0 - DEL ei k„y, 1 - DEL k„y, 2 - 2 columns! DEL k„y }
 { index:=1; }
 
  index:=abs(index);
+ NormalizeIndex;
 
   xx:=x-6;
   yy:=y-3+((index-1)*height);
@@ -848,24 +859,16 @@ begin  { phase: 0 - DEL ei k„y, 1 - DEL k„y, 2 - 2 columns! DEL k„y }
    'a'..'l' : index:=ord(ch)-87;
    end;
 
-   if (index<=0) or (index>items) then
-    begin
-     index:=items+2;
-     if (putkeen) then index:=items+1;
-    end;
+   NormalizeIndex;
 
    if (ch2=#71) then index:=1;
    if (ch=#27) or (ch2=#79) then
-    begin
-     index:=items+2;
-     if (putkeen) then index:=items+1;
-    end;
+    index:=GetLastIndex;
 
    if (ch2=#68) then { F10 }
     begin
      out:=true;
-     index:=items+2;
-     if (putkeen) then index:=items+1;
+     index:=GetLastIndex;
      if (phase=6) then index:=254;
     end;
 
@@ -2121,7 +2124,7 @@ begin
 
   DrawScreen;
 
-  index:=MakeMenu(60,11,80,8,20,1,243,0,0);
+  index:=MakeMenu(60,11,80,8,20,index,243,0,0);
 
   if (index=0) then leave:=true
                else edithill(h[index],filestr,false);
@@ -2484,7 +2487,7 @@ begin
 
    DrawScreen;
 
-   index:=MakeMenu(99,14,221,8,items,1,243,1,0);
+   index:=MakeMenu(99,14,221,8,items,index,243,1,0);
 
    leave:=false;
 


### PR DESCRIPTION
This Pull Request fixes all cases of the `MakeMenu` function being called with a fixed `index` parameter value, which made using the menus cumbersome in some of the cases.

The changed usages are:
* _Jump!_ / _Practise_ (Hill Select menu) — previously, after hitting the ESC key in practise, the cursor was set always to the first hill of the first page (Kuopio K120); now the cursor will remain at the previously selected hill
* _Jump!_ / _King of the Hill_ (KOTH Setup menu) — previously, changing any setting (ENTER key) moved the cursor the the first item (_Begin \*King of the Hill\*_); now the cursor will remain at the setting currently being altered
* _Jump!_ / _King of the Hill_ / _Select Challenge Level_ (Level Select menu) — like above, now the cursor will be set to the current challenge level after entering the setting
* _Jump!_ / _King of the Hill_ / _Jumping at_ (Hill Select menu) — like the Hill Select menu in Practise, now the cursor will be set to the currently selected hill after entering the setting
* _Setup Menu_ / _General Options_ / _Language?_ (Language Select menu) — previously, the cursor was set always to the first language (English); now the cursor will be set to the currently selected language after entering the setting
* _Setup Menu_ / _Hill Maker_ (File Select menu) — previously, after exiting the hill form, the cursor was set always to the first file of the current page; now the cursor will remain at the previously selected file

This required some further modifications:
* to the `selecthill` function — so it can accept an index value, and handle all the possible hill index values to set the correct page and cursor position
* to the `MakeMenu` function as well — so it can properly handle `0` as the `index` parameter value, a value which the function itself returns when selecting the last, "magic", 0.-indexed "exit" option (which is labelled _Custom_ in the KOTH Challenge Level menu and _Random WC Hill_ in the KOTH Hill Select menu)