### PR TITLE
Fix text overflow for replaced jumper name

### DIFF
--- a/SJ3INFO.PAS
+++ b/SJ3INFO.PAS
@@ -1525,12 +1525,17 @@ if (index>0) and (index<=NumProfiles) then
    begin
     str1:='';
 
+    x:=colx+4; y:=gety;
+
+    if (temp>15) then inc(y,8)
+                 else inc(x,fontlen(lstr(303+temp)));
+
     with Profile[index] do
      case temp of
      1 : str1:=name;
      2 : str1:=realname;
      5 : if (replace=0) then str1:='-'
-                        else str1:=nimet[replace];
+                        else str1:=nsh(nimet[replace],316-x);
      6 : if (cstyle=0) then str1:=lstr(9)
                        else str1:=lstr(361+cstyle*40);
      7 : str1:=lstr(231+skipquali);
@@ -1566,11 +1571,6 @@ if (index>0) and (index<=NumProfiles) then
      18 : if (kothlevel=0) then str1:='-'
                            else str1:=lstr(130+kothlevel);
      end;
-
-     x:=colx+4; y:=gety;
-
-     if (temp>15) then inc(y,8)
-                  else inc(x,fontlen(lstr(303+temp)));
 
      writefont(x,y,str1);
 
@@ -1675,7 +1675,7 @@ begin
 
   if (value>0) then
    begin
-    writefont(x,y,nsh(nimet[value],305-x));
+    writefont(x,y,nsh(nimet[value],316-fontlen('#'+txt(value))-x));
     ewritefont(316,y,'#'+txt(value));
    end else writefont(x,y,lstr(9));
 


### PR DESCRIPTION
In the jumper profile, the replaced jumper's name was incorrectly trimmed:
* While the setting was being edited, the name was trimmed not to exceed x=305. But this would be correct only for jumpers ranked #<!-- -->1-#<!-- -->9, and would still clash with the ranking number for jumpers ranked #<!-- -->10 and above.
* When the setting was only displayed, there was no trimming whatsoever.

This pull request fixes the issue.

| Before | After |
| ------ | ----- |
| <img width="668" height="466" alt="Active — before" src="https://github.com/user-attachments/assets/7b72ff73-2ae3-411c-9d39-14268f29e49a" /> | <img width="668" height="466" alt="Active — after" src="https://github.com/user-attachments/assets/024ac4ea-5c76-4907-8b9e-64b751865ec4" /> |
| <img width="668" height="466" alt="Inactive — before" src="https://github.com/user-attachments/assets/c223c041-4a5d-4183-aeb8-3505422f82c3" /> | <img width="668" height="466" alt="Inactive — after" src="https://github.com/user-attachments/assets/7ee8c062-e69b-4b16-8631-1795a3500cfa" /> |