### PR TITLE
Fix opponent nameset setup on case-sensitive-filename systems

### DIFF
--- a/SJ3.PAS
+++ b/SJ3.PAS
@@ -647,7 +647,7 @@ begin
 
              if (ch<>#27) then
               begin
-               assign(f3,'names'+ch+'.ski');
+               assign(f3,'NAMES'+ch+'.SKI');
                {$I-}
                reset(f3);
                {$I+}


### PR DESCRIPTION
The `LoadNames` procedure is loading the correct `NAMES_.SKI` file, but the setup menu is checking for the existence of a `names_.ski` file before allowing to change the selected nameset file — a check which will fail on a case-sensitive-filename (non-Windows) system.